### PR TITLE
🚀 Release/v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.4.1](https://github.com/routelink/client/compare/v1.4.0...v1.4.1) (2024-05-30)
+
+
+### Features
+
+* improve handler `api/analitycs/services/` ([#183](https://github.com/routelink/client/issues/183)) ([fa30132](https://github.com/routelink/client/commit/fa301321c66380f2cecee251fdd0fe1e78a6f821))
+
+
+### Bug Fixes
+
+* change endpoint to update transport ([b85ceff](https://github.com/routelink/client/commit/b85cefff7eee09e38381a57de4108650e24756b0))
+
 ## [1.4.0](https://github.com/routelink/client/compare/v1.3.0...v1.4.0) (2024-05-29)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@routelink/client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@routelink/client",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@routelink/client",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "postinstall": "npx husky install",


### PR DESCRIPTION
### [1.4.1](https://github.com/routelink/client/compare/v1.4.0...v1.4.1) (2024-05-30)

### Features

* improve handler `api/analitycs/services/` ([#183](https://github.com/routelink/client/issues/183)) ([fa30132](https://github.com/routelink/client/commit/fa301321c66380f2cecee251fdd0fe1e78a6f821))

### Bug Fixes

* change endpoint to update transport ([b85ceff](https://github.com/routelink/client/commit/b85cefff7eee09e38381a57de4108650e24756b0))

---

> **DO NOT SQUASH OR REBASE ME**

> if user merges this PR via rebasing or using squash, it will cause lost of the tag. It happens because tag is already
> attached to the initial release commit SHA. If we use rebase or squash, the commit sha changes and already created tag
> points to not-existing commit.