### PR TITLE
🚀 Release/v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.6.1](https://github.com/routelink/client/compare/v1.6.0...v1.6.1) (2024-05-30)
+
+
+### Bug Fixes
+
+* change user field ([c2f8810](https://github.com/routelink/client/commit/c2f8810223a77e32ab6f9a440c12b0549efd35b6))
+
 ## [1.6.0](https://github.com/routelink/client/compare/v1.5.0...v1.6.0) (2024-05-30)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@routelink/client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@routelink/client",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@routelink/client",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "postinstall": "npx husky install",


### PR DESCRIPTION
### [1.6.1](https://github.com/routelink/client/compare/v1.6.0...v1.6.1) (2024-05-30)

### Bug Fixes

* change user field ([c2f8810](https://github.com/routelink/client/commit/c2f8810223a77e32ab6f9a440c12b0549efd35b6))

---

> **DO NOT SQUASH OR REBASE ME**

> if user merges this PR via rebasing or using squash, it will cause lost of the tag. It happens because tag is already
> attached to the initial release commit SHA. If we use rebase or squash, the commit sha changes and already created tag
> points to not-existing commit.